### PR TITLE
Remove Percona knobs tests

### DIFF
--- a/suite_sets/resmoke_psmdb_3.2_big.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big.txt
@@ -28,7 +28,6 @@ core_small_oplog_rs,mmapv1,wiredTiger,PerconaFT,rocksdb
 jstestfuzz,mmapv1,wiredTiger,PerconaFT,rocksdb
 jstestfuzz_replication,wiredTiger,PerconaFT,rocksdb
 jstestfuzz_sharded,wiredTiger,PerconaFT,rocksdb
-knobs,mmapv1,wiredTiger,rocksdb
 mmap,mmapv1
 mongo_test,default
 multiversion,default


### PR DESCRIPTION
As per removal of https://github.com/percona/percona-server-mongodb/pull/93 we don't need knobs tests any more.