### PR TITLE
Redirect the output from a resmoke.py to a file

### DIFF
--- a/run_resmoke_psmdb_3.2.sh
+++ b/run_resmoke_psmdb_3.2.sh
@@ -89,7 +89,7 @@ runResmoke() {
 
   echo "Running Command: buildscripts/resmoke.py ${resmokeParams}" | tee -a "${logOutputFile}" 
   # shellcheck disable=SC2086
-  python buildscripts/resmoke.py ${resmokeParams} 2>&1 | tee -a "${logOutputFile}"
+  python buildscripts/resmoke.py ${resmokeParams} >>"${logOutputFile}" 2>&1
 
 }
 


### PR DESCRIPTION
Redirect the output from a resmoke.py to a file without printing on stdout
This is good for jenkins but you will have a status of which suite is running