### PR TITLE
Change in master suite for running multiversion tests

### DIFF
--- a/suite_sets/resmoke_psmdb_3.2_big_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_master.txt
@@ -33,7 +33,7 @@ mmap,mmapv1
 mongos_test,default
 multiversion,default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
-  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
+  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough,mmapv1,wiredTiger,rocksdb
 no_passthrough_with_mongod,mmapv1,wiredTiger,rocksdb
@@ -51,7 +51,7 @@ sharding_gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger
 sharding_jscore_passthrough,mmapv1,wiredTiger,rocksdb
 sharding_legacy_multiversion,default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
-  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
+  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 slow1,mmapv1,wiredTiger,rocksdb
 slow2,mmapv1,wiredTiger,rocksdb


### PR DESCRIPTION
2.4 has been removed and 3.2 added for running setup_multiversion_mongodb.py
Also in the current merge branch seems "base" is not used, although it's used in 3.2

2 tests are still failing:
```
js_tests: 25 test(s) ran in 563.90 seconds (23 succeeded, 0 were skipped, 2 failed, 0 errored)                                                                                                                             
The following tests failed (with exit code):                                                                                                                                                                           
   jstests/multiVersion/server-23299-1.js (253)                                                                                                                                                                       
   jstests/multiVersion/server-23299-2.js (253)
```

and most probably because of this:
```
Running:  python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
Downloading data for version 2.6 (2.6.12)...
Download url is http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz
Uncompressing data for version 2.6 (2.6.12)...
Downloading data for version 3.0 (3.0.14)...
Download url is http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.0.14.tgz
Uncompressing data for version 3.0 (3.0.14)...
Downloading data for version 3.2 (3.2.11)...
Download url is http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.2.11.tgz
Uncompressing data for version 3.2 (3.2.11)...
Skipping download for version 3.2.1 (3.2.11) since the dest already exists 'mongodb-linux-x86_64-3.2.11
```