### PR TITLE
Updated big master suite with newest suites from 3.4 and removed unused

### DIFF
--- a/suite_sets/resmoke_psmdb_3.2_big_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_master.txt
@@ -1,4 +1,6 @@
 aggregation,mmapv1,wiredTiger,inMemory,rocksdb
+aggregation_facet_unwind_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
+aggregation_sharded_collections_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
 aggregation_auth,default
 audit,mmapv1,wiredTiger,inMemory,rocksdb
 auth,mmapv1,wiredTiger,inMemory,rocksdb
@@ -8,17 +10,20 @@ bulk_gle_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
 concurrency,mmapv1,wiredTiger,inMemory,rocksdb
 concurrency_replication,mmapv1,wiredTiger,inMemory,rocksdb
 concurrency_sharded,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_sharded_sccc,mmapv1,wiredTiger,inMemory,rocksdb
 !concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,mmapv1,wiredTiger,inMemory,rocksdb
 core,mmapv1,wiredTiger,inMemory,rocksdb
+core_compression,default
 core_auth,default
 core --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,rocksdb
 core_small_oplog,mmapv1,wiredTiger,inMemory,rocksdb
 core_small_oplog_rs,mmapv1,wiredTiger,inMemory,rocksdb
+core_small_oplog_rs_initsync_static,mmapv1,wiredTiger,inMemory,rocksdb
+core_small_oplog_rs_resync_static,mmapv1,wiredTiger,inMemory,rocksdb
 dbtest,mmapv1,wiredTiger,inMemory,rocksdb
 disk,default
 dur_jscore_passthrough,default
 durability,default
+external_auth,default
 failpoints,default
 failpoints_auth,default
 gle_auth --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
@@ -33,29 +38,35 @@ mmap,mmapv1
 mongos_test,default
 multiversion,default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
-  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
+  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
+  $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
+multiversion_multistorage_engine,mmapv1,wiredTiger,inMemory,rocksdb
+  $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
+  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
 no_passthrough_with_mongod,mmapv1,wiredTiger,inMemory,rocksdb
 parallel,mmapv1,wiredTiger,inMemory,rocksdb
 parallel --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,rocksdb
 ratelimit,mmapv1,wiredTiger,inMemory,rocksdb
+read_only,mmapv1,wiredTiger,inMemory,rocksdb
+read_only_sharded,mmapv1,wiredTiger,inMemory,rocksdb
 replica_sets,mmapv1,wiredTiger,inMemory,rocksdb
 replica_sets_auth,default
 replication,mmapv1,wiredTiger,inMemory,rocksdb
 replication_auth,default
+serial_run,mmapv1,wiredTiger,inMemory,rocksdb
 sharding,mmapv1,wiredTiger,inMemory,rocksdb
 sharding_auth,default
+sharding_compression,default
 sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
 sharding_gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
 sharding_jscore_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_legacy_multiversion,default
-  $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
-  $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
-  $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
+sharding_last_stable_mongos_and_mixed_shards,default
 slow1,mmapv1,wiredTiger,inMemory,rocksdb
-slow2,mmapv1,wiredTiger,inMemory,rocksdb
 ssl,default
 ssl_special,default
 tool,mmapv1,wiredTiger,inMemory,rocksdb
 unittests,default
+views,mmapv1,wiredTiger,inMemory,rocksdb
+views_rs,mmapv1,wiredTiger,inMemory,rocksdb


### PR DESCRIPTION
**NON TOUCHED**
core_small_oplog_rs_initsync - listed, but doesn't run?
core_small_oplog_rs_resync  - listed, but doesn't run?
external_auth - new - runs on enterprise RHEL 7.0 and ent. Windows
replica_sets_compression - not included in any runs

**CHANGE NEEDED IN JENKINS**
ADD mongoreplay to tools build