### PR TITLE
Remove inMemory from master replica_sets suite because it's stalling

### DIFF
--- a/suite_sets/resmoke_psmdb_3.2_big_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_master.txt
@@ -51,7 +51,7 @@ parallel --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger
 ratelimit,mmapv1,wiredTiger,inMemory,rocksdb
 read_only,mmapv1,wiredTiger,inMemory,rocksdb
 read_only_sharded,mmapv1,wiredTiger,inMemory,rocksdb
-replica_sets,mmapv1,wiredTiger,inMemory,rocksdb
+replica_sets,mmapv1,wiredTiger,rocksdb
 replica_sets_auth,default
 replication,mmapv1,wiredTiger,inMemory,rocksdb
 replication_auth,default


### PR DESCRIPTION
There's some issue with inMemory engine and replica sets suite on the master branch that causes stalls so for now we will disable executing this.