### PR TITLE
Changed separator in suites definition from , to |

### DIFF
--- a/run_resmoke_psmdb_3.2.sh
+++ b/run_resmoke_psmdb_3.2.sh
@@ -100,7 +100,7 @@ for suite in "${SUITES[@]}"; do
     continue; 
   fi
 
-  IFS=',' read -r -a suiteDefinition <<< "${suite}"
+  IFS='|' read -r -a suiteDefinition <<< "${suite}"
   suiteElementNumber=0
 
   for suiteElement in "${suiteDefinition[@]}"; do
@@ -139,7 +139,7 @@ for suite in "${SUITES[@]}"; do
 
         "default"|"auth")
           logOutputFile="${logOutputFilePrefix}_${trial}.log"
-          echo "Suite Definition: ${suiteRawName},${suiteElement}" | tee -a "${logOutputFile}"
+          echo "Suite Definition: ${suiteRawName}|${suiteElement}" | tee -a "${logOutputFile}"
           [ "${suiteRunSet}" == "default" ] && resmokeParams=${RESMOKE_DEFAULT}
           [ "${suiteRunSet}" == "auth" ] && resmokeParams=${RESMOKE_AUTH}
           resmokeParams="${RESMOKE_BASE} ${resmokeParams} ${suiteOptions} ${suiteRunSetOptions}"
@@ -151,7 +151,7 @@ for suite in "${SUITES[@]}"; do
           ;;
         "wiredTiger"|"PerconaFT"|"rocksdb"|"mmapv1"|"inMemory")
           logOutputFile="${logOutputFilePrefix}_${trial}.log"
-          echo "Suite Definition: ${suiteRawName},${suiteElement}" | tee -a "${logOutputFile}"
+          echo "Suite Definition: ${suiteRawName}|${suiteElement}" | tee -a "${logOutputFile}"
           if hasEngine "${suiteRunSet}"; then
             resmokeParams="${RESMOKE_BASE} ${RESMOKE_SE} --storageEngine=${suiteRunSet} ${suiteOptions} ${suiteRunSetOptions}"
             if $useSuitesOption; then
@@ -171,9 +171,9 @@ for suite in "${SUITES[@]}"; do
             if [ ! "${engine}" == "${DEFAULT_ENGINE}" ]; then
               logOutputFile="${logOutputFilePrefix}_${engine}_${trial}.log"
               if [[ -z "${suiteRunSetOptions}" ]]; then
-                suiteDefinition="${suiteRawName},${engine}"
+                suiteDefinition="${suiteRawName}|${engine}"
               else
-                suiteDefinition="${suiteRawName},${engine} ${suiteRunSetOptions}"
+                suiteDefinition="${suiteRawName}|${engine} ${suiteRunSetOptions}"
               fi
               echo "Suite Definition: ${suiteDefinition}" | tee -a "${logOutputFile}"
               resmokeParams="${RESMOKE_BASE} --storageEngine=${engine} ${RESMOKE_SE} ${suiteOptions} ${suiteRunSetOptions}"

--- a/run_smoke_resmoke_funcs.sh
+++ b/run_smoke_resmoke_funcs.sh
@@ -133,7 +133,7 @@ runPreprocessingCommands() {
       fi
     fi
 
-    IFS=',' read -r -a suiteDefinition <<< "${suiteCommand}"
+    IFS='|' read -r -a suiteDefinition <<< "${suiteCommand}"
     suiteName="${suiteDefinition[0]}"
     if [ "${suiteName}" = "${suiteRawName}" ]; then
       foundCommandSuite=true

--- a/suite_sets/core_all_engines.txt
+++ b/suite_sets/core_all_engines.txt
@@ -1,1 +1,1 @@
-core,default,se
+core|default|se

--- a/suite_sets/core_default.txt
+++ b/suite_sets/core_default.txt
@@ -1,1 +1,1 @@
-core,default
+core|default

--- a/suite_sets/resmoke_psmdb_3.2_big.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big.txt
@@ -1,61 +1,61 @@
-aggregation,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-aggregation_auth,default
-audit,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-auth,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-auth_audit,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-backup,wiredTiger,rocksdb
-bulk_gle_passthrough,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-concurrency,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_replication,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-concurrency_sharded,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_sharded_sccc,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,mmapv1,wiredTiger,inMemory,rocksdb
-core,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-core_auth,default
-core --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-core_small_oplog,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-core_small_oplog_rs,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-dbtest,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-disk,default
-dur_jscore_passthrough,default
-durability,default
-failpoints,default
-failpoints_auth,default
-gle_auth --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-gle_auth --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-jstestfuzz,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-jstestfuzz_replication,wiredTiger,inMemory,PerconaFT,rocksdb
-jstestfuzz_sharded,wiredTiger,inMemory,PerconaFT,rocksdb
-knobs,mmapv1,wiredTiger,inMemory,rocksdb
-mmap,mmapv1
-mongos_test,default
-multiversion,default
+aggregation|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+aggregation_auth|default
+audit|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+auth|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+auth_audit|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+backup|wiredTiger|rocksdb
+bulk_gle_passthrough|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+concurrency|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_replication|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+concurrency_sharded|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_sharded_sccc|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|mmapv1|wiredTiger|inMemory|rocksdb
+core|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+core_auth|default
+core --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+core_small_oplog|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+core_small_oplog_rs|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+dbtest|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+disk|default
+dur_jscore_passthrough|default
+durability|default
+failpoints|default
+failpoints_auth|default
+gle_auth --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+gle_auth --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+jstestfuzz|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+jstestfuzz_replication|wiredTiger|inMemory|PerconaFT|rocksdb
+jstestfuzz_sharded|wiredTiger|inMemory|PerconaFT|rocksdb
+knobs|mmapv1|wiredTiger|inMemory|rocksdb
+mmap|mmapv1
+mongos_test|default
+multiversion|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-no_passthrough,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-no_passthrough_with_mongod,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-parallel,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-parallel --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-ratelimit,mmapv1,wiredTiger,inMemory,rocksdb
-replica_sets,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-replica_sets_auth,default
-replication,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-replication_auth,default
-sharding,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_auth,default
-sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-sharding_gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-sharding_jscore_passthrough,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-sharding_legacy_multiversion,default
+no_passthrough|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+parallel|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+parallel --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+ratelimit|mmapv1|wiredTiger|inMemory|rocksdb
+replica_sets|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+replica_sets_auth|default
+replication|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+replication_auth|default
+sharding|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_auth|default
+sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+sharding_gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+sharding_jscore_passthrough|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+sharding_legacy_multiversion|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-slow1,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-slow2,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-ssl,default
-ssl_special,default
-tool,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-unittests,default
+slow1|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+slow2|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+ssl|default
+ssl_special|default
+tool|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+unittests|default

--- a/suite_sets/resmoke_psmdb_3.2_big_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_master.txt
@@ -1,76 +1,76 @@
-aggregation,mmapv1,wiredTiger,inMemory,rocksdb
-aggregation_facet_unwind_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-aggregation_sharded_collections_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-aggregation_auth,default
-audit,mmapv1,wiredTiger,inMemory,rocksdb
-auth,mmapv1,wiredTiger,inMemory,rocksdb
-auth_audit,mmapv1,wiredTiger,inMemory,rocksdb
-backup,wiredTiger,rocksdb
-bulk_gle_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_replication,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_sharded,mmapv1,wiredTiger,inMemory,rocksdb
-!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,mmapv1,wiredTiger,inMemory,rocksdb
-core,mmapv1,wiredTiger,inMemory,rocksdb
-core_compression,default
-core_auth,default
-core --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,rocksdb
-core_small_oplog,mmapv1,wiredTiger,inMemory,rocksdb
-core_small_oplog_rs,mmapv1,wiredTiger,inMemory,rocksdb
-core_small_oplog_rs_initsync_static,mmapv1,wiredTiger,inMemory,rocksdb
-core_small_oplog_rs_resync_static,mmapv1,wiredTiger,inMemory,rocksdb
-dbtest,mmapv1,wiredTiger,inMemory,rocksdb
-disk,default
-dur_jscore_passthrough,default
-durability,default
-external_auth,default
-failpoints,default
-failpoints_auth,default
-gle_auth --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-jstestfuzz,mmapv1,wiredTiger,inMemory,rocksdb
-jstestfuzz_replication,wiredTiger,inMemory,rocksdb
-jstestfuzz_sharded,wiredTiger,inMemory,rocksdb
-knobs,mmapv1,wiredTiger,inMemory,rocksdb
-mmap,mmapv1
-mongos_test,default
-multiversion,default
+aggregation|mmapv1|wiredTiger|inMemory|rocksdb
+aggregation_facet_unwind_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+aggregation_sharded_collections_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+aggregation_auth|default
+audit|mmapv1|wiredTiger|inMemory|rocksdb
+auth|mmapv1|wiredTiger|inMemory|rocksdb
+auth_audit|mmapv1|wiredTiger|inMemory|rocksdb
+backup|wiredTiger|rocksdb
+bulk_gle_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_replication|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_sharded|mmapv1|wiredTiger|inMemory|rocksdb
+!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|mmapv1|wiredTiger|inMemory|rocksdb
+core|mmapv1|wiredTiger|inMemory|rocksdb
+core_compression|default
+core_auth|default
+core --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|rocksdb
+core_small_oplog|mmapv1|wiredTiger|inMemory|rocksdb
+core_small_oplog_rs|mmapv1|wiredTiger|inMemory|rocksdb
+core_small_oplog_rs_initsync_static|mmapv1|wiredTiger|inMemory|rocksdb
+core_small_oplog_rs_resync_static|mmapv1|wiredTiger|inMemory|rocksdb
+dbtest|mmapv1|wiredTiger|inMemory|rocksdb
+disk|default
+dur_jscore_passthrough|default
+durability|default
+external_auth|default
+failpoints|default
+failpoints_auth|default
+gle_auth --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+jstestfuzz|mmapv1|wiredTiger|inMemory|rocksdb
+jstestfuzz_replication|wiredTiger|inMemory|rocksdb
+jstestfuzz_sharded|wiredTiger|inMemory|rocksdb
+knobs|mmapv1|wiredTiger|inMemory|rocksdb
+mmap|mmapv1
+mongos_test|default
+multiversion|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-multiversion_multistorage_engine,mmapv1,wiredTiger,inMemory,rocksdb
+multiversion_multistorage_engine|mmapv1|wiredTiger|inMemory|rocksdb
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-no_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-no_passthrough_with_mongod,mmapv1,wiredTiger,inMemory,rocksdb
-parallel,mmapv1,wiredTiger,inMemory,rocksdb
-parallel --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,rocksdb
-percona_no_passthrough_with_mongod,mmapv1,wiredTiger,inMemory,rocksdb
-ratelimit,mmapv1,wiredTiger,inMemory,rocksdb
-read_only,mmapv1,wiredTiger,rocksdb
-read_only_sharded,mmapv1,wiredTiger,rocksdb
-replica_sets,mmapv1,wiredTiger,rocksdb
-replica_sets_auth,default
-replication,mmapv1,wiredTiger,inMemory,rocksdb
-replication_auth,default
-serial_run,mmapv1,wiredTiger,inMemory,rocksdb
-sharding,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_auth,default
-sharding_compression,default
-sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_jscore_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_last_stable_mongos_and_mixed_shards,default
+no_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|rocksdb
+parallel|mmapv1|wiredTiger|inMemory|rocksdb
+parallel --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|rocksdb
+percona_no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|rocksdb
+ratelimit|mmapv1|wiredTiger|inMemory|rocksdb
+read_only|mmapv1|wiredTiger|rocksdb
+read_only_sharded|mmapv1|wiredTiger|rocksdb
+replica_sets|mmapv1|wiredTiger|rocksdb
+replica_sets_auth|default
+replication|mmapv1|wiredTiger|inMemory|rocksdb
+replication_auth|default
+serial_run|mmapv1|wiredTiger|inMemory|rocksdb
+sharding|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_auth|default
+sharding_compression|default
+sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_jscore_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_last_stable_mongos_and_mixed_shards|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-slow1,mmapv1,wiredTiger,inMemory,rocksdb
-ssl,default
-ssl_special,default
-tool,mmapv1,wiredTiger,inMemory,rocksdb
-unittests,default
-views,mmapv1,wiredTiger,inMemory,rocksdb
-views_rs,mmapv1,wiredTiger,inMemory,rocksdb
+slow1|mmapv1|wiredTiger|inMemory|rocksdb
+ssl|default
+ssl_special|default
+tool|mmapv1|wiredTiger|inMemory|rocksdb
+unittests|default
+views|mmapv1|wiredTiger|inMemory|rocksdb
+views_rs|mmapv1|wiredTiger|inMemory|rocksdb

--- a/suite_sets/resmoke_psmdb_3.2_big_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_master.txt
@@ -3,8 +3,10 @@ aggregation_facet_unwind_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
 aggregation_sharded_collections_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
 aggregation_auth|default
 audit|mmapv1|wiredTiger|inMemory|rocksdb
-auth|mmapv1|wiredTiger|inMemory|rocksdb
-auth_audit|mmapv1|wiredTiger|inMemory|rocksdb
+auth|mmapv1|wiredTiger|rocksdb
+auth --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
+auth_audit|mmapv1|wiredTiger|rocksdb
+auth_audit --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
 backup|wiredTiger|rocksdb
 bulk_gle_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
 concurrency|mmapv1|wiredTiger|inMemory|rocksdb
@@ -44,8 +46,10 @@ multiversion_multistorage_engine|mmapv1|wiredTiger|inMemory|rocksdb
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-no_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
-no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|rocksdb
+no_passthrough|mmapv1|wiredTiger|rocksdb
+no_passthrough --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
+no_passthrough_with_mongod|mmapv1|wiredTiger|rocksdb
+no_passthrough_with_mongod --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
 parallel|mmapv1|wiredTiger|inMemory|rocksdb
 parallel --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|rocksdb
 percona_no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|rocksdb
@@ -54,10 +58,12 @@ read_only|mmapv1|wiredTiger|rocksdb
 read_only_sharded|mmapv1|wiredTiger|rocksdb
 replica_sets|mmapv1|wiredTiger|rocksdb
 replica_sets_auth|default
-replication|mmapv1|wiredTiger|inMemory|rocksdb
+replication|mmapv1|wiredTiger|rocksdb
+replication --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
 replication_auth|default
 serial_run|mmapv1|wiredTiger|inMemory|rocksdb
-sharding|mmapv1|wiredTiger|inMemory|rocksdb
+sharding|mmapv1|wiredTiger|rocksdb
+sharding --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
 sharding_auth|default
 sharding_compression|default
 sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
@@ -72,5 +78,6 @@ ssl|default
 ssl_special|default
 tool|mmapv1|wiredTiger|inMemory|rocksdb
 unittests|default
-views|mmapv1|wiredTiger|inMemory|rocksdb
+views|mmapv1|wiredTiger|rocksdb
+views --excludeWithAnyTags=requires_persistence,requires_journaling|inMemory
 views_rs|mmapv1|wiredTiger|inMemory|rocksdb

--- a/suite_sets/resmoke_psmdb_3.2_big_nopft.txt
+++ b/suite_sets/resmoke_psmdb_3.2_big_nopft.txt
@@ -1,61 +1,61 @@
-aggregation,mmapv1,wiredTiger,inMemory,rocksdb
-aggregation_auth,default
-audit,mmapv1,wiredTiger,inMemory,rocksdb
-auth,mmapv1,wiredTiger,inMemory,rocksdb
-auth_audit,mmapv1,wiredTiger,inMemory,rocksdb
-backup,wiredTiger,rocksdb
-bulk_gle_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_replication,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_sharded,mmapv1,wiredTiger,inMemory,rocksdb
-concurrency_sharded_sccc,mmapv1,wiredTiger,inMemory,rocksdb
-!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,mmapv1,wiredTiger,inMemory,rocksdb
-core,mmapv1,PerconaFT,wiredTiger,inMemory,rocksdb
-core_auth,default
-core --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,PerconaFT,wiredTiger,inMemory,rocksdb
-core_small_oplog,mmapv1,PerconaFT,wiredTiger,inMemory,rocksdb
-core_small_oplog_rs,mmapv1,PerconaFT,wiredTiger,inMemory,rocksdb
-dbtest,mmapv1,wiredTiger,inMemory,rocksdb
-disk,default
-dur_jscore_passthrough,default
-durability,default
-failpoints,default
-failpoints_auth,default
-gle_auth --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-jstestfuzz,mmapv1,wiredTiger,inMemory,rocksdb
-jstestfuzz_replication,wiredTiger,inMemory,rocksdb
-jstestfuzz_sharded,wiredTiger,inMemory,rocksdb
-knobs,mmapv1,wiredTiger,inMemory,rocksdb
-mmap,mmapv1
-mongos_test,default
-multiversion,default
+aggregation|mmapv1|wiredTiger|inMemory|rocksdb
+aggregation_auth|default
+audit|mmapv1|wiredTiger|inMemory|rocksdb
+auth|mmapv1|wiredTiger|inMemory|rocksdb
+auth_audit|mmapv1|wiredTiger|inMemory|rocksdb
+backup|wiredTiger|rocksdb
+bulk_gle_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_replication|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_sharded|mmapv1|wiredTiger|inMemory|rocksdb
+concurrency_sharded_sccc|mmapv1|wiredTiger|inMemory|rocksdb
+!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|mmapv1|wiredTiger|inMemory|rocksdb
+core|mmapv1|PerconaFT|wiredTiger|inMemory|rocksdb
+core_auth|default
+core --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|PerconaFT|wiredTiger|inMemory|rocksdb
+core_small_oplog|mmapv1|PerconaFT|wiredTiger|inMemory|rocksdb
+core_small_oplog_rs|mmapv1|PerconaFT|wiredTiger|inMemory|rocksdb
+dbtest|mmapv1|wiredTiger|inMemory|rocksdb
+disk|default
+dur_jscore_passthrough|default
+durability|default
+failpoints|default
+failpoints_auth|default
+gle_auth --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+jstestfuzz|mmapv1|wiredTiger|inMemory|rocksdb
+jstestfuzz_replication|wiredTiger|inMemory|rocksdb
+jstestfuzz_sharded|wiredTiger|inMemory|rocksdb
+knobs|mmapv1|wiredTiger|inMemory|rocksdb
+mmap|mmapv1
+mongos_test|default
+multiversion|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-no_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-no_passthrough_with_mongod,mmapv1,wiredTiger,inMemory,rocksdb
-parallel,mmapv1,wiredTiger,inMemory,rocksdb
-parallel --shellReadMode=legacy --shellWriteMode=compatibility,mmapv1,wiredTiger,inMemory,rocksdb
-ratelimit,mmapv1,wiredTiger,inMemory,rocksdb
-replica_sets,mmapv1,wiredTiger,inMemory,rocksdb
-replica_sets_auth,default
-replication,mmapv1,wiredTiger,inMemory,rocksdb
-replication_auth,default
-sharding,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_auth,default
-sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_gle_auth_basics_passthrough --shellWriteMode=commands,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_jscore_passthrough,mmapv1,wiredTiger,inMemory,rocksdb
-sharding_legacy_multiversion,default
+no_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+no_passthrough_with_mongod|mmapv1|wiredTiger|inMemory|rocksdb
+parallel|mmapv1|wiredTiger|inMemory|rocksdb
+parallel --shellReadMode=legacy --shellWriteMode=compatibility|mmapv1|wiredTiger|inMemory|rocksdb
+ratelimit|mmapv1|wiredTiger|inMemory|rocksdb
+replica_sets|mmapv1|wiredTiger|inMemory|rocksdb
+replica_sets_auth|default
+replication|mmapv1|wiredTiger|inMemory|rocksdb
+replication_auth|default
+sharding|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_auth|default
+sharding_gle_auth_basics_passthrough --shellWriteMode=legacy --shellReadMode=legacy|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_gle_auth_basics_passthrough --shellWriteMode=commands|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_jscore_passthrough|mmapv1|wiredTiger|inMemory|rocksdb
+sharding_legacy_multiversion|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.4" "2.6" "3.0" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-slow1,mmapv1,wiredTiger,inMemory,rocksdb
-slow2,mmapv1,wiredTiger,inMemory,rocksdb
-ssl,default
-ssl_special,default
-tool,mmapv1,wiredTiger,inMemory,rocksdb
-unittests,default
+slow1|mmapv1|wiredTiger|inMemory|rocksdb
+slow2|mmapv1|wiredTiger|inMemory|rocksdb
+ssl|default
+ssl_special|default
+tool|mmapv1|wiredTiger|inMemory|rocksdb
+unittests|default

--- a/suite_sets/resmoke_psmdb_3.2_default.txt
+++ b/suite_sets/resmoke_psmdb_3.2_default.txt
@@ -1,1 +1,1 @@
-core,default,se
+core|default|se

--- a/suite_sets/resmoke_psmdb_3.2_medium.txt
+++ b/suite_sets/resmoke_psmdb_3.2_medium.txt
@@ -1,42 +1,42 @@
-aggregation,default
-aggregation_auth,default
-audit,wiredTiger,PerconaFT,rocksdb
-auth,default
-auth_audit,default
-backup,wiredTiger,rocksdb
-bulk_gle_passthrough,wiredTiger,PerconaFT,rocksdb
-concurrency,wiredTiger,rocksdb
-concurrency_replication,wiredTiger,PerconaFT,rocksdb
-concurrency_sharded,wiredTiger,rocksdb
-concurrency_sharded_sccc,default
-!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,wiredTiger,rocksdb
-core,mmapv1,wiredTiger,inMemory,PerconaFT,rocksdb
-core_auth,default
-core_small_oplog,wiredTiger,inMemory,PerconaFT,rocksdb
-core_small_oplog_rs,wiredTiger,inMemory,PerconaFT,rocksdb
-dbtest,wiredTiger,PerconaFT,rocksdb
-disk,default
-dur_jscore_passthrough,default
-durability,default
-failpoints,default
-failpoints_auth,default
- jstestfuzz,wiredTiger,PerconaFT,rocksdb
- jstestfuzz_replication,wiredTiger,PerconaFT,rocksdb
- jstestfuzz_sharded,wiredTiger,PerconaFT,rocksdb
-knobs,wiredTiger,rocksdb
-mongos_test,default
-no_passthrough,wiredTiger,PerconaFT,rocksdb
-no_passthrough_with_mongod,wiredTiger,rocksdb
-parallel,wiredTiger,rocksdb
-ratelimit,wiredTiger,rocksdb
-replica_sets,default
-replica_sets_auth,default
-replication,default
-replication_auth,default
-sharding,default
-sharding_auth,default
-sharding_jscore_passthrough,wiredTiger,PerconaFT,rocksdb
-ssl,default
-ssl_special,default
-tool,wiredTiger,PerconaFT,rocksdb
-unittests,default
+aggregation|default
+aggregation_auth|default
+audit|wiredTiger|PerconaFT|rocksdb
+auth|default
+auth_audit|default
+backup|wiredTiger|rocksdb
+bulk_gle_passthrough|wiredTiger|PerconaFT|rocksdb
+concurrency|wiredTiger|rocksdb
+concurrency_replication|wiredTiger|PerconaFT|rocksdb
+concurrency_sharded|wiredTiger|rocksdb
+concurrency_sharded_sccc|default
+!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|wiredTiger|rocksdb
+core|mmapv1|wiredTiger|inMemory|PerconaFT|rocksdb
+core_auth|default
+core_small_oplog|wiredTiger|inMemory|PerconaFT|rocksdb
+core_small_oplog_rs|wiredTiger|inMemory|PerconaFT|rocksdb
+dbtest|wiredTiger|PerconaFT|rocksdb
+disk|default
+dur_jscore_passthrough|default
+durability|default
+failpoints|default
+failpoints_auth|default
+ jstestfuzz|wiredTiger|PerconaFT|rocksdb
+ jstestfuzz_replication|wiredTiger|PerconaFT|rocksdb
+ jstestfuzz_sharded|wiredTiger|PerconaFT|rocksdb
+knobs|wiredTiger|rocksdb
+mongos_test|default
+no_passthrough|wiredTiger|PerconaFT|rocksdb
+no_passthrough_with_mongod|wiredTiger|rocksdb
+parallel|wiredTiger|rocksdb
+ratelimit|wiredTiger|rocksdb
+replica_sets|default
+replica_sets_auth|default
+replication|default
+replication_auth|default
+sharding|default
+sharding_auth|default
+sharding_jscore_passthrough|wiredTiger|PerconaFT|rocksdb
+ssl|default
+ssl_special|default
+tool|wiredTiger|PerconaFT|rocksdb
+unittests|default

--- a/suite_sets/resmoke_psmdb_3.2_medium_master.txt
+++ b/suite_sets/resmoke_psmdb_3.2_medium_master.txt
@@ -1,57 +1,57 @@
-aggregation,default
-aggregation_auth,default
-audit,wiredTiger,rocksdb
-auth,default
-auth_audit,default
-backup,wiredTiger,rocksdb
-bulk_gle_passthrough,wiredTiger,rocksdb
-concurrency,wiredTiger,rocksdb
-concurrency_replication,wiredTiger,rocksdb
-concurrency_sharded,wiredTiger,rocksdb
-concurrency_sharded_sccc,default
-!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js,wiredTiger,rocksdb
-core,mmapv1,wiredTiger,inMemory,rocksdb
-core_compression,default
-core_auth,default
-core_small_oplog,wiredTiger,inMemory,rocksdb
-core_small_oplog_rs,wiredTiger,inMemory,rocksdb
-dbtest,wiredTiger,rocksdb
-disk,default
-dur_jscore_passthrough,default
-durability,default
-failpoints,default
-failpoints_auth,default
- jstestfuzz,wiredTiger,rocksdb
- jstestfuzz_replication,wiredTiger,rocksdb
- jstestfuzz_sharded,wiredTiger,rocksdb
-knobs,wiredTiger,rocksdb
-mongos_test,default
-no_passthrough,wiredTiger,rocksdb
-no_passthrough_with_mongod,wiredTiger,rocksdb
-parallel,wiredTiger,rocksdb
-ratelimit,wiredTiger,rocksdb
-replica_sets,default
-multiversion_multistorage_engine,wiredTiger,inMemory,rocksdb
+aggregation|default
+aggregation_auth|default
+audit|wiredTiger|rocksdb
+auth|default
+auth_audit|default
+backup|wiredTiger|rocksdb
+bulk_gle_passthrough|wiredTiger|rocksdb
+concurrency|wiredTiger|rocksdb
+concurrency_replication|wiredTiger|rocksdb
+concurrency_sharded|wiredTiger|rocksdb
+concurrency_sharded_sccc|default
+!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|wiredTiger|rocksdb
+core|mmapv1|wiredTiger|inMemory|rocksdb
+core_compression|default
+core_auth|default
+core_small_oplog|wiredTiger|inMemory|rocksdb
+core_small_oplog_rs|wiredTiger|inMemory|rocksdb
+dbtest|wiredTiger|rocksdb
+disk|default
+dur_jscore_passthrough|default
+durability|default
+failpoints|default
+failpoints_auth|default
+ jstestfuzz|wiredTiger|rocksdb
+ jstestfuzz_replication|wiredTiger|rocksdb
+ jstestfuzz_sharded|wiredTiger|rocksdb
+knobs|wiredTiger|rocksdb
+mongos_test|default
+no_passthrough|wiredTiger|rocksdb
+no_passthrough_with_mongod|wiredTiger|rocksdb
+parallel|wiredTiger|rocksdb
+ratelimit|wiredTiger|rocksdb
+replica_sets|default
+multiversion_multistorage_engine|wiredTiger|inMemory|rocksdb
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-percona_no_passthrough_with_mongod,wiredTiger,rocksdb
-read_only,wiredTiger,rocksdb
-read_only_sharded,wiredTiger,rocksdb
-replica_sets_auth,default
-replication,default
-replication_auth,default
-serial_run,default
-sharding,default
-sharding_auth,default
-sharding_jscore_passthrough,wiredTiger,rocksdb
-sharding_last_stable_mongos_and_mixed_shards,default
+percona_no_passthrough_with_mongod|wiredTiger|rocksdb
+read_only|wiredTiger|rocksdb
+read_only_sharded|wiredTiger|rocksdb
+replica_sets_auth|default
+replication|default
+replication_auth|default
+serial_run|default
+sharding|default
+sharding_auth|default
+sharding_jscore_passthrough|wiredTiger|rocksdb
+sharding_last_stable_mongos_and_mixed_shards|default
   $ rm -rf ${DBPATH}/install ${DBPATH}/multiversion
   $ python buildscripts/setup_multiversion_mongodb.py ${DBPATH}/install ${DBPATH}/multiversion "base" "Linux/x86_64" "2.6" "3.0" "3.2" "3.2.1"
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
-ssl,default
-ssl_special,default
-tool,wiredTiger,rocksdb
-unittests,default
-views,default
-views_rs,default
+ssl|default
+ssl_special|default
+tool|wiredTiger|rocksdb
+unittests|default
+views|default
+views_rs|default


### PR DESCRIPTION
Changed separator in suites definition from , to | to support multiple resmoke parameters like `--excludeWithAnyTags=requires_persistence,requires_journaling`.

Added separate suites for inMemory which pass `--excludeWithAnyTags=requires_persistence,requires_journaling` which skips the tests that have those tags in definition - since upstream MongoDB runs the tests like this also.