### PR TITLE
Fix running of single test with specific executor

### DIFF
--- a/run_resmoke_psmdb_3.2.sh
+++ b/run_resmoke_psmdb_3.2.sh
@@ -118,11 +118,13 @@ for suite in "${SUITES[@]}"; do
       suite=${suiteElementName}
       suiteRawName=${suite}
       suiteOptions=${suiteElementOptions}
-      suiteLogTag=$(echo "${suiteElement}" | sed -r -e 's/ +/_/g' -e 's/[-!]//g')
+      suiteLogTag=$(echo "${suiteElement}" | sed -r -e 's/ +/_/g' -e 's/[-!/]//g')
 
       if [[ "${suite}" == *"!"* ]]; then
         useSuitesOption=false
         suite=${suite#!}
+        suiteOptions=$(echo ${suite}|cut -d " " -f2-)
+        suite=$(echo ${suite}|cut -d " " -f1)
       elif [[ "${suiteOptions}" == *"--suites"* ]]; then
         useSuitesOption=false
       else


### PR DESCRIPTION
This is for tests specified like so:
```
!concurrency_simultaneous --executor=concurrency jstests/concurrency/fsm_all_simultaneous.js|mmapv1|wiredTiger|inMemory|rocksdb
```