### PR TITLE
PQA-311 run detectEngines only once but before any test suites

### DIFF
--- a/run_resmoke_psmdb_3.2.sh
+++ b/run_resmoke_psmdb_3.2.sh
@@ -74,6 +74,11 @@ fi
 # returns SUITES
 load_suite_set "${basedir}" "${suiteSet}"
 
+
+# detect storage engines
+# returns DEFAULT_ENGINE, ENGINES
+detectEngines
+
 # main script
 
 runResmoke() {
@@ -180,9 +185,6 @@ for suite in "${SUITES[@]}"; do
           fi
           ;;
         "se")
-
-          detectEngines
-
           for engine in "${ENGINES[@]}"; do
 
             if [ ! "${engine}" == "${DEFAULT_ENGINE}" ]; then


### PR DESCRIPTION
Fixes resmoke parameters for test suites with the 'default' specifier

WIthout this fix `detectEngines` is called only if test suite has `se` storage engine specifier. But with the fix for PQA-311 `DEFAULT_ENGINE` is also used in the `default|auth` case.
Also now `detectEngines` is called only once.