### PR TITLE
fix test suite for 4.2 and master

### DIFF
--- a/run_resmoke_psmdb_3.2.sh
+++ b/run_resmoke_psmdb_3.2.sh
@@ -36,17 +36,17 @@ source "${basedir}/run_smoke_resmoke_funcs.sh"
 
 # smoke parameters
 RESMOKE_JOBS=$(grep -cw ^processor /proc/cpuinfo)
-RESMOKE_BASE="--continueOnFailure --jobs=${RESMOKE_JOBS} --shuffle --storageEngineCacheSizeGB=1"
+RESMOKE_BASE="--continueOnFailure --jobs=${RESMOKE_JOBS} --shuffle"
 RESMOKE_DEFAULT=""
 RESMOKE_AUTH="--auth"
 RESMOKE_SE=""
 
-# default tags to exclude per SE
-RESMOKE_EXCLUDE_wiredTiger="--excludeWithAnyTags=requires_mmapv1"
-RESMOKE_EXCLUDE_PerconaFT=""
-RESMOKE_EXCLUDE_rocksdb=""
-RESMOKE_EXCLUDE_mmapv1="--excludeWithAnyTags=requires_wiredtiger,uses_transactions,requires_document_locking,requires_majority_read_concern,uses_change_streams"
-RESMOKE_EXCLUDE_inMemory="--excludeWithAnyTags=requires_persistence,requires_journaling,requires_mmapv1,uses_transactions"
+# default options for specific SE
+RESMOKE_SE_DEFAULT_wiredTiger="--storageEngineCacheSizeGB=1 --excludeWithAnyTags=requires_mmapv1"
+RESMOKE_SE_DEFAULT_PerconaFT=""
+RESMOKE_SE_DEFAULT_rocksdb=""
+RESMOKE_SE_DEFAULT_mmapv1="--storageEngineCacheSizeGB=1 --excludeWithAnyTags=requires_wiredtiger,uses_transactions,requires_document_locking,requires_majority_read_concern,uses_change_streams"
+RESMOKE_SE_DEFAULT_inMemory="--storageEngineCacheSizeGB=4 --excludeWithAnyTags=requires_persistence,requires_journaling,requires_mmapv1,uses_transactions"
 
 run_system_validations
 
@@ -161,8 +161,8 @@ for suite in "${SUITES[@]}"; do
           echo "Suite Definition: ${suiteRawName}${suiteOptions:+ ${suiteOptions}}|${suiteElement}" | tee -a "${logOutputFile}"
           [ "${suiteRunSet}" == "default" ] && resmokeParams=${RESMOKE_DEFAULT}
           [ "${suiteRunSet}" == "auth" ] && resmokeParams=${RESMOKE_AUTH}
-          excludeTagsVar="RESMOKE_EXCLUDE_${DEFAULT_ENGINE}"
-          resmokeParams="${RESMOKE_BASE} ${resmokeParams} ${!excludeTagsVar} ${suiteOptions} ${suiteRunSetOptions}"
+          seDefaultOpts="RESMOKE_SE_DEFAULT_${DEFAULT_ENGINE}"
+          resmokeParams="${RESMOKE_BASE} ${resmokeParams} ${!seDefaultOpts} ${suiteOptions} ${suiteRunSetOptions}"
           if $useSuitesOption; then
             resmokeParams="${resmokeParams} --suites=${suite}"
           fi
@@ -174,8 +174,8 @@ for suite in "${SUITES[@]}"; do
           echo "-----------------" | tee -a "${logOutputFile}"
           echo "Suite Definition: ${suiteRawName}${suiteOptions:+ ${suiteOptions}}|${suiteElement}" | tee -a "${logOutputFile}"
           if hasEngine "${suiteRunSet}"; then
-            excludeTagsVar="RESMOKE_EXCLUDE_${suiteRunSet}"
-            resmokeParams="${RESMOKE_BASE} ${RESMOKE_SE} --storageEngine=${suiteRunSet} ${!excludeTagsVar} ${suiteOptions} ${suiteRunSetOptions}"
+            seDefaultOpts="RESMOKE_SE_DEFAULT_${suiteRunSet}"
+            resmokeParams="${RESMOKE_BASE} ${RESMOKE_SE} --storageEngine=${suiteRunSet} ${!seDefaultOpts} ${suiteOptions} ${suiteRunSetOptions}"
             if $useSuitesOption; then
               resmokeParams="${resmokeParams} --suites=${suite}"
             fi
@@ -196,8 +196,8 @@ for suite in "${SUITES[@]}"; do
               fi
               echo "-----------------" | tee -a "${logOutputFile}"
               echo "Suite Definition: ${suiteDefinition}${suiteOptions:+ ${suiteOptions}}" | tee -a "${logOutputFile}"
-              excludeTagsVar="RESMOKE_EXCLUDE_${engine}"
-              resmokeParams="${RESMOKE_BASE} --storageEngine=${engine} ${RESMOKE_SE} ${!excludeTagsVar} ${suiteOptions} ${suiteRunSetOptions}"
+              seDefaultOpts="RESMOKE_SE_DEFAULT_${engine}"
+              resmokeParams="${RESMOKE_BASE} --storageEngine=${engine} ${RESMOKE_SE} ${!seDefaultOpts} ${suiteOptions} ${suiteRunSetOptions}"
               if $useSuitesOption; then
                 resmokeParams="${resmokeParams} --suites=${suite}"
               fi

--- a/suite_sets/resmoke_psmdb_4.2_big.txt
+++ b/suite_sets/resmoke_psmdb_4.2_big.txt
@@ -34,25 +34,25 @@ change_streams_whole_db_passthrough|wiredTiger|inMemory
 change_streams_whole_db_secondary_reads_passthrough|wiredTiger|inMemory
 change_streams_whole_db_sharded_collections_passthrough|wiredTiger|inMemory
 client_encrypt|wiredTiger|inMemory
-concurrency|wiredTiger|inMemory
-concurrency_replication|wiredTiger|inMemory
-concurrency_replication_causal_consistency|wiredTiger|inMemory
-concurrency_replication_causal_consistency_ubsan|wiredTiger|inMemory
-concurrency_replication_multi_stmt_txn|wiredTiger|inMemory
-concurrency_replication_multi_stmt_txn_ubsan|wiredTiger|inMemory
-concurrency_sharded_causal_consistency|wiredTiger|inMemory
-concurrency_sharded_causal_consistency_and_balancer|wiredTiger|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn|wiredTiger|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn_with_balancer|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn_with_stepdowns|wiredTiger|inMemory
-concurrency_sharded_replication|wiredTiger|inMemory
-concurrency_sharded_replication_with_balancer|wiredTiger|inMemory
-concurrency_sharded_with_stepdowns|wiredTiger|inMemory
-concurrency_sharded_with_stepdowns_and_balancer|wiredTiger|inMemory
-concurrency_simultaneous|wiredTiger|inMemory
-concurrency_simultaneous_replication|wiredTiger|inMemory
+concurrency --jobs=1|wiredTiger|inMemory
+concurrency_replication --jobs=1|wiredTiger|inMemory
+concurrency_replication_causal_consistency --jobs=1|wiredTiger|inMemory
+concurrency_replication_causal_consistency_ubsan --jobs=1|wiredTiger|inMemory
+concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger|inMemory
+concurrency_sharded_causal_consistency --jobs=1|wiredTiger|inMemory
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|wiredTiger|inMemory
+concurrency_sharded_replication --jobs=1|wiredTiger|inMemory
+concurrency_sharded_replication_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_with_stepdowns --jobs=1|wiredTiger|inMemory
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger|inMemory
+concurrency_simultaneous --jobs=1|wiredTiger|inMemory
+concurrency_simultaneous_replication --jobs=1|wiredTiger|inMemory
 core|wiredTiger|inMemory
 core_auth|default
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger|inMemory
@@ -110,8 +110,8 @@ multiversion_auth|wiredTiger
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|wiredTiger|inMemory
 no_passthrough_with_mongod|wiredTiger|inMemory
-parallel|wiredTiger|inMemory
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger|inMemory
+parallel --jobs=1|wiredTiger|inMemory
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|wiredTiger|inMemory
 percona_no_passthrough_with_mongod|wiredTiger|inMemory
 ratelimit|wiredTiger|inMemory
 read_concern_majority_passthrough|wiredTiger|inMemory
@@ -161,9 +161,11 @@ sharding_rs_matching_disabled|wiredTiger|inMemory
 sharding_rs_matching_match_busiest_node|wiredTiger|inMemory
 sharding_tde_cbc|default
 sharding_tde_gcm|default
-slow1|wiredTiger|inMemory
+slow1 --jobs=1|wiredTiger|inMemory
 ssl|default
 ssl_special|default
 tool|wiredTiger|inMemory
  unittests|default
+watchdog --jobs=1|wiredTiger|inMemory
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|wiredTiger|inMemory

--- a/suite_sets/resmoke_psmdb_4.2_big_inMemory.txt
+++ b/suite_sets/resmoke_psmdb_4.2_big_inMemory.txt
@@ -28,23 +28,23 @@ change_streams_whole_db_mongos_passthrough|inMemory
 change_streams_whole_db_passthrough|inMemory
 change_streams_whole_db_sharded_collections_passthrough|inMemory
 client_encrypt|inMemory
-concurrency|inMemory
-concurrency_replication|inMemory
-concurrency_replication_causal_consistency|inMemory
-concurrency_replication_multi_stmt_txn|inMemory
-concurrency_sharded_causal_consistency|inMemory
-concurrency_sharded_causal_consistency_and_balancer|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|inMemory
-concurrency_sharded_multi_stmt_txn|inMemory
-concurrency_sharded_multi_stmt_txn_with_balancer|inMemory
-concurrency_sharded_multi_stmt_txn_with_stepdowns|inMemory
-concurrency_sharded_replication|inMemory
-concurrency_sharded_replication_with_balancer|inMemory
-concurrency_sharded_with_stepdowns|inMemory
-concurrency_sharded_with_stepdowns_and_balancer|inMemory
-concurrency_simultaneous|inMemory
-concurrency_simultaneous_replication|inMemory
+concurrency --jobs=1|inMemory
+concurrency_replication --jobs=1|inMemory
+concurrency_replication_causal_consistency --jobs=1|inMemory
+concurrency_replication_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_causal_consistency --jobs=1|inMemory
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|inMemory
+concurrency_sharded_replication --jobs=1|inMemory
+concurrency_sharded_replication_with_balancer --jobs=1|inMemory
+concurrency_sharded_with_stepdowns --jobs=1|inMemory
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|inMemory
+concurrency_simultaneous --jobs=1|inMemory
+concurrency_simultaneous_replication --jobs=1|inMemory
 core|inMemory
 core_auth|inMemory
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|inMemory
@@ -99,8 +99,8 @@ multi_stmt_txn_jscore_passthrough_with_migration|inMemory
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|inMemory
 no_passthrough_with_mongod|inMemory
-parallel|inMemory
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|inMemory
+parallel --jobs=1|inMemory
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
 percona_no_passthrough_with_mongod|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
@@ -146,9 +146,11 @@ sharding_jscore_passthrough --shellWriteMode=compatibility --shellReadMode=legac
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 sharding_rs_matching_disabled|inMemory
 sharding_rs_matching_match_busiest_node|inMemory
-slow1|inMemory
+slow1 --jobs=1|inMemory
 ssl|inMemory
 ssl_special|inMemory
 tool|inMemory
  unittests|default
+watchdog --jobs=1|inMemory
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|inMemory

--- a/suite_sets/resmoke_psmdb_4.2_big_wiredTiger.txt
+++ b/suite_sets/resmoke_psmdb_4.2_big_wiredTiger.txt
@@ -34,25 +34,25 @@ change_streams_whole_db_passthrough|wiredTiger
 change_streams_whole_db_secondary_reads_passthrough|wiredTiger
 change_streams_whole_db_sharded_collections_passthrough|wiredTiger
 client_encrypt|wiredTiger
-concurrency|wiredTiger
-concurrency_replication|wiredTiger
-concurrency_replication_causal_consistency|wiredTiger
-concurrency_replication_causal_consistency_ubsan|wiredTiger
-concurrency_replication_multi_stmt_txn|wiredTiger
-concurrency_replication_multi_stmt_txn_ubsan|wiredTiger
-concurrency_sharded_causal_consistency|wiredTiger
-concurrency_sharded_causal_consistency_and_balancer|wiredTiger
-concurrency_sharded_local_read_write_multi_stmt_txn|wiredTiger
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|wiredTiger
-concurrency_sharded_multi_stmt_txn|wiredTiger
-concurrency_sharded_multi_stmt_txn_with_balancer|wiredTiger
-concurrency_sharded_multi_stmt_txn_with_stepdowns|wiredTiger
-concurrency_sharded_replication|wiredTiger
-concurrency_sharded_replication_with_balancer|wiredTiger
-concurrency_sharded_with_stepdowns|wiredTiger
-concurrency_sharded_with_stepdowns_and_balancer|wiredTiger
-concurrency_simultaneous|wiredTiger
-concurrency_simultaneous_replication|wiredTiger
+concurrency --jobs=1|wiredTiger
+concurrency_replication --jobs=1|wiredTiger
+concurrency_replication_causal_consistency --jobs=1|wiredTiger
+concurrency_replication_causal_consistency_ubsan --jobs=1|wiredTiger
+concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger
+concurrency_sharded_causal_consistency --jobs=1|wiredTiger
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|wiredTiger
+concurrency_sharded_replication --jobs=1|wiredTiger
+concurrency_sharded_replication_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_with_stepdowns --jobs=1|wiredTiger
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger
+concurrency_simultaneous --jobs=1|wiredTiger
+concurrency_simultaneous_replication --jobs=1|wiredTiger
 core|wiredTiger
 core_auth|default
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger
@@ -110,8 +110,8 @@ multiversion_auth|wiredTiger
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|wiredTiger
 no_passthrough_with_mongod|wiredTiger
-parallel|wiredTiger
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger
+parallel --jobs=1|wiredTiger
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|wiredTiger
 percona_no_passthrough_with_mongod|wiredTiger
 ratelimit|wiredTiger
 read_concern_majority_passthrough|wiredTiger
@@ -161,9 +161,11 @@ sharding_rs_matching_disabled|wiredTiger
 sharding_rs_matching_match_busiest_node|wiredTiger
 sharding_tde_cbc|default
 sharding_tde_gcm|default
-slow1|wiredTiger
+slow1 --jobs=1|wiredTiger
 ssl|default
 ssl_special|default
 tool|wiredTiger
  unittests|default
+watchdog --jobs=1|wiredTiger
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|wiredTiger

--- a/suite_sets/resmoke_psmdb_master_big.txt
+++ b/suite_sets/resmoke_psmdb_master_big.txt
@@ -34,25 +34,25 @@ change_streams_whole_db_passthrough|wiredTiger|inMemory
 change_streams_whole_db_secondary_reads_passthrough|wiredTiger|inMemory
 change_streams_whole_db_sharded_collections_passthrough|wiredTiger|inMemory
 client_encrypt|wiredTiger|inMemory
-concurrency|wiredTiger|inMemory
-concurrency_replication|wiredTiger|inMemory
-concurrency_replication_causal_consistency|wiredTiger|inMemory
-concurrency_replication_causal_consistency_ubsan|wiredTiger|inMemory
-concurrency_replication_multi_stmt_txn|wiredTiger|inMemory
-concurrency_replication_multi_stmt_txn_ubsan|wiredTiger|inMemory
-concurrency_sharded_causal_consistency|wiredTiger|inMemory
-concurrency_sharded_causal_consistency_and_balancer|wiredTiger|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn|wiredTiger|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn_with_balancer|wiredTiger|inMemory
-concurrency_sharded_multi_stmt_txn_with_stepdowns|wiredTiger|inMemory
-concurrency_sharded_replication|wiredTiger|inMemory
-concurrency_sharded_replication_with_balancer|wiredTiger|inMemory
-concurrency_sharded_with_stepdowns|wiredTiger|inMemory
-concurrency_sharded_with_stepdowns_and_balancer|wiredTiger|inMemory
-concurrency_simultaneous|wiredTiger|inMemory
-concurrency_simultaneous_replication|wiredTiger|inMemory
+concurrency --jobs=1|wiredTiger|inMemory
+concurrency_replication --jobs=1|wiredTiger|inMemory
+concurrency_replication_causal_consistency --jobs=1|wiredTiger|inMemory
+concurrency_replication_causal_consistency_ubsan --jobs=1|wiredTiger|inMemory
+concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger|inMemory
+concurrency_sharded_causal_consistency --jobs=1|wiredTiger|inMemory
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|wiredTiger|inMemory
+concurrency_sharded_replication --jobs=1|wiredTiger|inMemory
+concurrency_sharded_replication_with_balancer --jobs=1|wiredTiger|inMemory
+concurrency_sharded_with_stepdowns --jobs=1|wiredTiger|inMemory
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger|inMemory
+concurrency_simultaneous --jobs=1|wiredTiger|inMemory
+concurrency_simultaneous_replication --jobs=1|wiredTiger|inMemory
 core|wiredTiger|inMemory
 core_auth|default
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger|inMemory
@@ -110,8 +110,8 @@ multiversion_auth|wiredTiger
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|wiredTiger|inMemory
 no_passthrough_with_mongod|wiredTiger|inMemory
-parallel|wiredTiger|inMemory
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger|inMemory
+parallel --jobs=1|wiredTiger|inMemory
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|wiredTiger|inMemory
 percona_no_passthrough_with_mongod|wiredTiger|inMemory
 ratelimit|wiredTiger|inMemory
 read_concern_majority_passthrough|wiredTiger|inMemory
@@ -161,9 +161,11 @@ sharding_rs_matching_disabled|wiredTiger|inMemory
 sharding_rs_matching_match_busiest_node|wiredTiger|inMemory
 sharding_tde_cbc|default
 sharding_tde_gcm|default
-slow1|wiredTiger|inMemory
+slow1 --jobs=1|wiredTiger|inMemory
 ssl|default
 ssl_special|default
 tool|wiredTiger|inMemory
  unittests|default
+watchdog --jobs=1|wiredTiger|inMemory
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|wiredTiger|inMemory

--- a/suite_sets/resmoke_psmdb_master_big_inMemory.txt
+++ b/suite_sets/resmoke_psmdb_master_big_inMemory.txt
@@ -28,23 +28,23 @@ change_streams_whole_db_mongos_passthrough|inMemory
 change_streams_whole_db_passthrough|inMemory
 change_streams_whole_db_sharded_collections_passthrough|inMemory
 client_encrypt|inMemory
-concurrency|inMemory
-concurrency_replication|inMemory
-concurrency_replication_causal_consistency|inMemory
-concurrency_replication_multi_stmt_txn|inMemory
-concurrency_sharded_causal_consistency|inMemory
-concurrency_sharded_causal_consistency_and_balancer|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn|inMemory
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|inMemory
-concurrency_sharded_multi_stmt_txn|inMemory
-concurrency_sharded_multi_stmt_txn_with_balancer|inMemory
-concurrency_sharded_multi_stmt_txn_with_stepdowns|inMemory
-concurrency_sharded_replication|inMemory
-concurrency_sharded_replication_with_balancer|inMemory
-concurrency_sharded_with_stepdowns|inMemory
-concurrency_sharded_with_stepdowns_and_balancer|inMemory
-concurrency_simultaneous|inMemory
-concurrency_simultaneous_replication|inMemory
+concurrency --jobs=1|inMemory
+concurrency_replication --jobs=1|inMemory
+concurrency_replication_causal_consistency --jobs=1|inMemory
+concurrency_replication_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_causal_consistency --jobs=1|inMemory
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|inMemory
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|inMemory
+concurrency_sharded_replication --jobs=1|inMemory
+concurrency_sharded_replication_with_balancer --jobs=1|inMemory
+concurrency_sharded_with_stepdowns --jobs=1|inMemory
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|inMemory
+concurrency_simultaneous --jobs=1|inMemory
+concurrency_simultaneous_replication --jobs=1|inMemory
 core|inMemory
 core_auth|inMemory
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|inMemory
@@ -99,8 +99,8 @@ multi_stmt_txn_jscore_passthrough_with_migration|inMemory
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|inMemory
 no_passthrough_with_mongod|inMemory
-parallel|inMemory
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|inMemory
+parallel --jobs=1|inMemory
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
 percona_no_passthrough_with_mongod|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
@@ -146,9 +146,11 @@ sharding_jscore_passthrough --shellWriteMode=compatibility --shellReadMode=legac
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 sharding_rs_matching_disabled|inMemory
 sharding_rs_matching_match_busiest_node|inMemory
-slow1|inMemory
+slow1 --jobs=1|inMemory
 ssl|inMemory
 ssl_special|inMemory
 tool|inMemory
  unittests|default
+watchdog --jobs=1|inMemory
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|inMemory

--- a/suite_sets/resmoke_psmdb_master_big_wiredTiger.txt
+++ b/suite_sets/resmoke_psmdb_master_big_wiredTiger.txt
@@ -34,25 +34,25 @@ change_streams_whole_db_passthrough|wiredTiger
 change_streams_whole_db_secondary_reads_passthrough|wiredTiger
 change_streams_whole_db_sharded_collections_passthrough|wiredTiger
 client_encrypt|wiredTiger
-concurrency|wiredTiger
-concurrency_replication|wiredTiger
-concurrency_replication_causal_consistency|wiredTiger
-concurrency_replication_causal_consistency_ubsan|wiredTiger
-concurrency_replication_multi_stmt_txn|wiredTiger
-concurrency_replication_multi_stmt_txn_ubsan|wiredTiger
-concurrency_sharded_causal_consistency|wiredTiger
-concurrency_sharded_causal_consistency_and_balancer|wiredTiger
-concurrency_sharded_local_read_write_multi_stmt_txn|wiredTiger
-concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer|wiredTiger
-concurrency_sharded_multi_stmt_txn|wiredTiger
-concurrency_sharded_multi_stmt_txn_with_balancer|wiredTiger
-concurrency_sharded_multi_stmt_txn_with_stepdowns|wiredTiger
-concurrency_sharded_replication|wiredTiger
-concurrency_sharded_replication_with_balancer|wiredTiger
-concurrency_sharded_with_stepdowns|wiredTiger
-concurrency_sharded_with_stepdowns_and_balancer|wiredTiger
-concurrency_simultaneous|wiredTiger
-concurrency_simultaneous_replication|wiredTiger
+concurrency --jobs=1|wiredTiger
+concurrency_replication --jobs=1|wiredTiger
+concurrency_replication_causal_consistency --jobs=1|wiredTiger
+concurrency_replication_causal_consistency_ubsan --jobs=1|wiredTiger
+concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger
+concurrency_sharded_causal_consistency --jobs=1|wiredTiger
+concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger
+concurrency_sharded_local_read_write_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_sharded_local_read_write_multi_stmt_txn_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_multi_stmt_txn_with_stepdowns --jobs=1|wiredTiger
+concurrency_sharded_replication --jobs=1|wiredTiger
+concurrency_sharded_replication_with_balancer --jobs=1|wiredTiger
+concurrency_sharded_with_stepdowns --jobs=1|wiredTiger
+concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger
+concurrency_simultaneous --jobs=1|wiredTiger
+concurrency_simultaneous_replication --jobs=1|wiredTiger
 core|wiredTiger
 core_auth|default
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger
@@ -110,8 +110,8 @@ multiversion_auth|wiredTiger
   $ [[ ${PATH} == *"/data/multiversion"* ]] || export PATH=${PATH}:/data/multiversion
 no_passthrough|wiredTiger
 no_passthrough_with_mongod|wiredTiger
-parallel|wiredTiger
-parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger
+parallel --jobs=1|wiredTiger
+parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|wiredTiger
 percona_no_passthrough_with_mongod|wiredTiger
 ratelimit|wiredTiger
 read_concern_majority_passthrough|wiredTiger
@@ -161,9 +161,11 @@ sharding_rs_matching_disabled|wiredTiger
 sharding_rs_matching_match_busiest_node|wiredTiger
 sharding_tde_cbc|default
 sharding_tde_gcm|default
-slow1|wiredTiger
+slow1 --jobs=1|wiredTiger
 ssl|default
 ssl_special|default
 tool|wiredTiger
  unittests|default
+watchdog --jobs=1|wiredTiger
+  $ jstests/watchdog/charybdefs_setup.sh
 write_concern_majority_passthrough|wiredTiger


### PR DESCRIPTION
Changes here are following:
1. previously tests for all storage engines were running with "--storageEngineCacheSizeGB=1" but that is not enough now for inMemory, so I have renamed options like "RESMOKE_EXCLUDE_wiredTiger" to "RESMOKE_SE_DEFAULT_wiredTiger" and use this to set "--storageEngineCacheSizeGB=4" for inMemory and "--storageEngineCacheSizeGB=1" for others. Upstream is running inMemory tests also with this amount of memory.

2. Some concurrency test suites were failing mostly for inMemory, but I have noticed that upstream is running these test suites with --jobs=1 (probably because each test actually runs with concurrency - but didn't check this) - so this is now specified in the test suites.

3. Added watchdog test suite which was enterprise before and somehow I skipped to add in previous cleanup. It still has some issues, but IMHO this is just probably test issue so we'll need to work on it more.

quick test run:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-param/24/testReport/(root)/
(shows resolved issues for slow1 and concurrency tests, other failures are not related to these changes)

big_wiredTiger run:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-param/23/
(before merging check test results)

big_inMemory run:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-param/22/
(before merging check test results)